### PR TITLE
Fixed email sending

### DIFF
--- a/pyOutlook/core/message.py
+++ b/pyOutlook/core/message.py
@@ -275,7 +275,7 @@ class Message(object):
 
         """
 
-        headers = {"Authorization": "Bearer " + self.account.access_token, "Content-Type": "application/json"}
+        headers = {"Authorization": "Bearer " + self.account, "Content-Type": "application/json"}
 
         if extra_headers is not None:
             headers.update(extra_headers)


### PR DESCRIPTION
When sending messages, as part of the header creation, pyOutlook would try to access 'self.account.access_token'. 
Upon debugging, account actually doesn't have an 'access_token' attribute, and 'account' itself is a string containing the access token.
Upon removal of the redundant 'access_token', sending messages is now possible again.
Tested by me.
NOTE: I'm on 2.7.