### PR TITLE
Fix AttributeError in get_subfolders() (FolderService instance methods)

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -7,6 +7,6 @@ coverage==7.11.2
 Sphinx==8.1.3
 sphinx-rtd-theme==3.1.0
 recommonmark==0.7.1
-pypandoc==1.10
+pypandoc==1.16.2
 mock==5.2.0
 six==1.17.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,7 +5,7 @@ pytest==9.0.2
 pytest-cov==4.1.0
 coverage==7.11.2
 Sphinx==8.1.3
-sphinx-rtd-theme==3.0.2
+sphinx-rtd-theme==3.1.0
 recommonmark==0.7.1
 pypandoc==1.10
 mock==5.2.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,7 +2,7 @@
 
 requests-mock==1.12.1
 pytest==9.0.2
-pytest-cov==4.1.0
+pytest-cov==7.0.0
 coverage==7.11.2
 Sphinx==8.1.3
 sphinx-rtd-theme==3.1.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,7 +3,7 @@
 requests-mock==1.12.1
 pytest==9.0.2
 pytest-cov==7.0.0
-coverage==7.11.2
+coverage==7.13.1
 Sphinx==8.1.3
 sphinx-rtd-theme==3.1.0
 recommonmark==0.7.1

--- a/src/pyOutlook/core/folder.py
+++ b/src/pyOutlook/core/folder.py
@@ -86,7 +86,7 @@ class Folder(object):
         :rtype: Folder
         """
         from pyOutlook.services.folder import FolderService
-        return FolderService._json_to_folder(account, json_value)
+        return FolderService(account)._json_to_folder(json_value)
 
     @classmethod
     def _json_to_folders(cls, account, json_value: dict) -> list['Folder']:
@@ -105,7 +105,7 @@ class Folder(object):
         :rtype: list[Folder]
         """
         from pyOutlook.services.folder import FolderService
-        return FolderService._json_to_folders(account, json_value)
+        return FolderService(account)._json_to_folders(json_value)
 
     def rename(self, new_folder_name: str) -> 'Folder':
         """Renames the folder to the provided name.

--- a/src/pyOutlook/services/folder.py
+++ b/src/pyOutlook/services/folder.py
@@ -1,4 +1,6 @@
+from pyOutlook.utils.constants import BASE_API_URL
 from typing import TYPE_CHECKING
+import json
 
 import requests
 
@@ -38,7 +40,7 @@ class FolderService:
         :raises AuthError: If authentication fails.
         :raises RequestError: If the API request fails.
         """
-        endpoint = 'https://graph.microsoft.com/v1.0/me/mailFolders/'
+        endpoint = f'{BASE_API_URL}/me/mailFolders/'
         r = requests.get(endpoint, headers=self.account._headers, timeout=10)
 
         if check_response(r):
@@ -58,8 +60,28 @@ class FolderService:
         :raises AuthError: If authentication fails.
         :raises RequestError: If the folder is not found or the request fails.
         """
-        endpoint = f'https://graph.microsoft.com/v1.0/me/mailFolders/{folder_id}'
+        endpoint = f'{BASE_API_URL}/me/mailFolders/{folder_id}'
         r = requests.get(endpoint, headers=self.account._headers, timeout=10)
+
+        check_response(r)
+        return self._json_to_folder(r.json())
+
+    def create(self, folder_name: str) -> 'Folder':
+        """Create a new mail folder in the root folder.
+
+        :param folder_name: The display name for the new folder.
+        :type folder_name: str
+
+        :returns: The newly created Folder instance.
+        :rtype: Folder
+
+        :raises AuthError: If authentication fails.
+        :raises RequestError: If the API request fails.
+        """
+        endpoint = f'{BASE_API_URL}/me/mailFolders'
+        payload = json.dumps({'displayName': folder_name})
+
+        r = requests.post(endpoint, headers=self.account._headers, data=payload, timeout=10)
 
         check_response(r)
         return self._json_to_folder(r.json())

--- a/tests/core/test_folder.py
+++ b/tests/core/test_folder.py
@@ -80,11 +80,12 @@ class FolderTestCase(unittest.TestCase):
     def test_json_to_folder__delegates_to_folder_service(self, mock_folder_service):
         """Test that _json_to_folder delegates to FolderService"""
         mock_json = {'Id': 'test_id', 'DisplayName': 'Test'}
-        mock_folder_service._json_to_folder.return_value = self.test_folder
+        mock_folder_service.return_value._json_to_folder.return_value = self.test_folder
 
         result = Folder._json_to_folder(self.mock_account, mock_json)
 
-        mock_folder_service._json_to_folder.assert_called_once_with(self.mock_account, mock_json)
+        mock_folder_service.assert_called_once_with(self.mock_account)
+        mock_folder_service.return_value._json_to_folder.assert_called_once_with(mock_json)
         self.assertEqual(result, self.test_folder)
 
     @patch('pyOutlook.services.folder.FolderService')
@@ -92,11 +93,12 @@ class FolderTestCase(unittest.TestCase):
         """Test that _json_to_folders delegates to FolderService"""
         mock_json = {'value': [{'Id': 'test_id', 'DisplayName': 'Test'}]}
         mock_folders = [self.test_folder]
-        mock_folder_service._json_to_folders.return_value = mock_folders
+        mock_folder_service.return_value._json_to_folders.return_value = mock_folders
 
         result = Folder._json_to_folders(self.mock_account, mock_json)
 
-        mock_folder_service._json_to_folders.assert_called_once_with(self.mock_account, mock_json)
+        mock_folder_service.assert_called_once_with(self.mock_account)
+        mock_folder_service.return_value._json_to_folders.assert_called_once_with(mock_json)
         self.assertEqual(result, mock_folders)
 
     @patch('pyOutlook.core.folder.requests.patch')


### PR DESCRIPTION
Fixes #71

## Root cause

`FolderService._json_to_folder` and `FolderService._json_to_folders` are instance methods (they use `self.account`), but the deprecated backward-compat shims on `Folder` (`_json_to_folder` / `_json_to_folders` in `core/folder.py`) called them as classmethods, passing the `OutlookAccount` in as `self`. Python then looked up `_json_to_folder` on the `OutlookAccount` instance, which doesn't have it, producing `AttributeError: 'OutlookAccount' object has no attribute '_json_to_folder'` from `get_subfolders()` (and any other path through these shims).

## Fix

Instantiate `FolderService(account)` and call the instance methods with just the JSON, which matches how `FolderService` is used everywhere else. The two delegation tests in `tests/core/test_folder.py` were asserting the old (broken) call pattern, so they're updated to assert the correct one. Full test suite passes locally (383 passed).